### PR TITLE
Add configurable label position

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Current supported portal locations:
 
 ![example_poh_labels.png](assets/example_poh_labels.png)
 
+### Configuration
+The plugin now includes a **Text Position** option so you can choose where the
+labels appear relative to each portal (Top, Middle, or Bottom).
+
 ## Helpful Tools
 
 ### What does `PortalNameEventSubscriber` do?

--- a/src/main/java/com/portalname/PortalNameConfig.java
+++ b/src/main/java/com/portalname/PortalNameConfig.java
@@ -14,6 +14,14 @@ public interface PortalNameConfig extends Config {
         MULTI
     }
 
+    // Position of the label relative to the portal
+    enum TextPosition
+    {
+        TOP,
+        MIDDLE,
+        BOTTOM
+    }
+
     @ConfigItem(
             keyName = "colorStyle",
             name = "Color Style",
@@ -22,6 +30,16 @@ public interface PortalNameConfig extends Config {
     default ColorStyle colorStyle()
     {
         return ColorStyle.SINGLE;   // Default to single color
+    }
+
+    @ConfigItem(
+            keyName = "textPosition",
+            name = "Text Position",
+            description = "Where labels are drawn relative to the portal"
+    )
+    default TextPosition textPosition()
+    {
+        return TextPosition.MIDDLE;
     }
 
 

--- a/src/main/java/com/portalname/PortalNameOverlay.java
+++ b/src/main/java/com/portalname/PortalNameOverlay.java
@@ -16,8 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.awt.*;
 import java.util.HashMap;
 import javax.inject.Inject;
-import javax.sound.sampled.Port;
 import java.util.Map;
+import com.portalname.PortalNameConfig.TextPosition;
 
 
 @Slf4j
@@ -210,11 +210,24 @@ public class PortalNameOverlay extends Overlay
                         LocalPoint localLocation = gameObject.getLocalLocation();
                         if (localLocation != null)
                         {
-                            // Use localToCanvas with height offset so it appears *above* the portal
-                            int zOffset = 100;
+                            // Offset determines where the label is drawn on the portal
+                            int zOffset;
+                            switch (config.textPosition())
+                            {
+                                case TOP:
+                                    zOffset = 150;
+                                    break;
+                                case BOTTOM:
+                                    zOffset = 20;
+                                    break;
+                                case MIDDLE:
+                                default:
+                                    zOffset = 100;
+                                    break;
+                            }
                             int xOffset = -15;
-                            Point textLocation = Perspective.localToCanvas(client, localLocation, client.getLocalPlayer().getWorldLocation().getPlane()
-                                    , zOffset);
+                            Point textLocation = Perspective.localToCanvas(client, localLocation,
+                                    client.getLocalPlayer().getWorldLocation().getPlane(), zOffset);
                             if (textLocation != null)
                             {
                                 graphics.setColor(Color.BLACK); // outline


### PR DESCRIPTION
## Summary
- let users position labels at the top, middle or bottom of a portal
- document the new `Text Position` config option

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686473081dc4832b9a9ceba648b0b5dd