### PR TITLE
Configure repo URL for semantic-release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,4 +1,5 @@
 {
+  "repositoryUrl": "https://github.com/jcbmcn/poh-portal-labels.git",
   "branches": ["main", "master"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {


### PR DESCRIPTION
## Summary
- specify `repositoryUrl` for semantic-release