### PR TITLE
Fix branch config for semantic release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-  "branches": [master"],
+  "branches": ["master"],
   "repositoryUrl": "https://github.com/jcbmcn/poh-portal-labels.git",
   "plugins": [
     ["@semantic-release/commit-analyzer", {


### PR DESCRIPTION
## Summary
- fix JSON syntax in `.releaserc` so semantic-release picks up the `master` branch

## Testing
- `npx semantic-release --dry-run` *(fails: cannot find module 'human-signals')*

------
https://chatgpt.com/codex/tasks/task_e_686497a2b4fc832bbd84c1573d41282e