### PR TITLE
fix(portal-validation): Allow portal objects with null names (IDs 136…

### DIFF
--- a/src/main/java/com/portalname/PortalNameOverlay.java
+++ b/src/main/java/com/portalname/PortalNameOverlay.java
@@ -165,9 +165,9 @@ public class PortalNameOverlay extends Overlay
         PORTAL_LABELS.put(33109, "Yanille");
         PORTAL_LABELS.put(56048, "Yanille");
         PORTAL_LABELS.put(33096, "Yanille Watchtower");
-        PORTAL_LABELS.put(13620, "Yanille Watchtower"); // pulled from event subscriber
         PORTAL_LABELS.put(33108, "Yanille Watchtower");
         PORTAL_LABELS.put(56047, "Yanille Watchtower");
+        PORTAL_LABELS.put(13620, "Yanille Watchtower"); // pulled from event subscriber
     }
 
     private final Map<String, Color> portalColors = new HashMap<>();
@@ -463,7 +463,16 @@ public class PortalNameOverlay extends Overlay
 
     private boolean isPortalObject(GameObject gameObject)
     {
-        net.runelite.api.ObjectComposition composition = client.getObjectDefinition(gameObject.getId());
+        int id = gameObject.getId();
+
+        // Object IDs 13615-13633 are portal frames/components with null or inconsistent names
+        // These are valid portal objects that should display labels
+        if (id >= 13615 && id <= 13633)
+        {
+            return true;
+        }
+
+        net.runelite.api.ObjectComposition composition = client.getObjectDefinition(id);
         if (composition == null)
         {
             return false;


### PR DESCRIPTION
…15-13633)

Portal objects in the ID range 13615-13633 have null names in their object definitions. These are portal frames/components that are valid portal objects but were being filtered out by the isPortalObject() validation check.

This fix adds an explicit range check to allow these objects, ensuring labels display correctly for portals like Yanille Watchtower, Grand Exchange, and Camelot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)