### PR TITLE
fix: add build=standard for plugin-hub packaging

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -3,4 +3,4 @@ author=jcbmcn
 description=Adds labels of destinations to POH portals.
 tags=portal,poh,construction,name,ui
 plugins=com.portalname.PortalNamePlugin
-support=https://github.com/jcbmcn/poh-portal-labels
+build=standard


### PR DESCRIPTION
## What

Adds `build=standard` to `runelite-plugin.properties`.

## Why

The RuneLite plugin-hub packager now requires an explicit build type and rejects the plugin without one:

```
poh-portal-labels: "build" must be set
You must add a build=standard or build=gradle entry.
```

This is what breaks the plugin-hub submission build. `standard` is correct: the custom `build.gradle` (shadowJar + test launcher) exists only for local testing, so the hub builds `src/main` against RuneLite directly.

Also removes the unused non-standard `support` key, which the packager warns about.

After this releases, the plugin-hub PR manifest gets repointed at the new release commit.
